### PR TITLE
Add Compose chat UI scaffold with previews

### DIFF
--- a/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
@@ -1,0 +1,48 @@
+package com.booji.foundryconnect.ui
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.booji.foundryconnect.data.network.Message
+
+/**
+ * Simple ViewModel holding chat state for the UI layer.
+ *
+ * Currently this only stores messages typed by the user and responses
+ * that will later come from the repository. Networking will be wired
+ * in a future sprint.
+ */
+class ChatViewModel : ViewModel() {
+
+    /** List of chat messages shown in the UI. */
+    val messages = mutableStateListOf<Message>()
+
+    /** Current text in the input field. */
+    var inputText by mutableStateOf("")
+
+    /** Flag indicating an in-flight network request. */
+    var isLoading by mutableStateOf(false)
+
+    /** Holds the latest error message, if any. */
+    var errorMessage by mutableStateOf<String?>(null)
+
+    /**
+     * Sends a user message. This is a stub that simply echoes the prompt back
+     * as an assistant response. Real network integration will be added later.
+     */
+    fun sendMessage(prompt: String) {
+        if (prompt.isBlank()) return
+
+        messages += Message(role = "user", content = prompt)
+        inputText = ""
+
+        // Placeholder loading flow
+        isLoading = true
+        // Fake immediate "response" for previewing purposes
+        messages += Message(role = "assistant", content = "Echo: $prompt")
+        isLoading = false
+        errorMessage = null
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/ui/components/MessageBubble.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/components/MessageBubble.kt
@@ -1,16 +1,35 @@
 package com.booji.foundryconnect.ui.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.material3.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 /**
- * Component to display individual chat messages as bubbles.
- *
- * TODO(Codex):
- * - Take parameters for message text, sender type (user or AI), and timestamp (optional).
- * - Differentiate styling clearly between sent (user) and received (AI) messages.
+ * Simple message bubble used in the chat list.
+ * Styling is intentionally basic for now – real visuals can iterate later.
  */
 @Composable
 fun MessageBubble(message: String, isUser: Boolean) {
-    // TODO(Codex): Implement message bubble styling and layout clearly here.
+    val bubbleColor = if (isUser) MaterialTheme.colorScheme.primary else Color.LightGray
+    val contentColor = if (isUser) Color.White else Color.Black
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = bubbleColor, contentColor = contentColor),
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .padding(if (isUser) 8.dp else 4.dp)
+    ) {
+        Box(modifier = Modifier.padding(8.dp), contentAlignment = Alignment.CenterStart) {
+            Text(text = message)
+        }
+    }
 }

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
@@ -1,22 +1,139 @@
 package com.booji.foundryconnect.ui.screens
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.material3.Text
-import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.booji.foundryconnect.data.network.Message
+import com.booji.foundryconnect.ui.ChatViewModel
+import com.booji.foundryconnect.ui.components.MessageBubble
 
 /**
  * Main UI screen showing chat interactions between user and Azure Foundry model.
- *
- * TODO(Codex):
- * - Implement chat message display using LazyColumn (scrollable vertically).
- * - Manage state effectively (consider ViewModel or Compose state hoisting).
- * - Implement real-time sending and receiving of messages, including loading indicators and error handling.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChatScreen() {
+fun ChatScreen(viewModel: ChatViewModel = remember { ChatViewModel() }) {
+    val error = viewModel.errorMessage
+    val loading = viewModel.isLoading
+
+    val messages = viewModel.messages
     Scaffold(
-        topBar = { /* TODO: Add top bar composable */ },
-        content = { /* TODO: Implement Chat UI here */},
-        bottomBar = { /* TODO: Add message input composable */ }
-    )
+        topBar = {
+            TopAppBar(title = { Text("Foundry Chat") })
+        },
+        bottomBar = {
+            MessageInput(
+                text = viewModel.inputText,
+                onTextChange = { viewModel.inputText = it },
+                onSend = { viewModel.sendMessage(it) },
+                enabled = !loading
+            )
+        }
+    ) { inner ->
+        Box(modifier = Modifier.padding(inner).fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(8.dp),
+                reverseLayout = false
+            ) {
+                items(messages) { msg ->
+                    MessageBubble(message = msg.content, isUser = msg.role == "user")
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+
+            if (loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            error?.let { err ->
+                Text(
+                    text = err,
+                    color = Color.Red,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(8.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageInput(
+    text: String,
+    onTextChange: (String) -> Unit,
+    onSend: (String) -> Unit,
+    enabled: Boolean
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+    ) {
+        TextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier.weight(1f),
+            enabled = enabled,
+            placeholder = { Text("Type a message") }
+        )
+        Spacer(Modifier.width(8.dp))
+        Button(onClick = { onSend(text) }, enabled = enabled) {
+            Text("Send")
+        }
+    }
+}
+
+// -------- Previews ---------
+
+@Preview(showBackground = true)
+@Composable
+private fun EmptyChatPreview() {
+    val vm = remember { ChatViewModel() }
+    ChatScreen(viewModel = vm)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FilledChatPreview() {
+    val vm = remember {
+        ChatViewModel().apply {
+            messages += Message("user", "Hello")
+            messages += Message("assistant", "Hi there!")
+        }
+    }
+    ChatScreen(viewModel = vm)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoadingPreview() {
+    val vm = remember {
+        ChatViewModel().apply {
+            isLoading = true
+        }
+    }
+    ChatScreen(viewModel = vm)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ErrorPreview() {
+    val vm = remember {
+        ChatViewModel().apply {
+            errorMessage = "Something went wrong"
+        }
+    }
+    ChatScreen(viewModel = vm)
 }


### PR DESCRIPTION
## Summary
- implement `ChatViewModel` to hold messages, loading state and input text
- implement simple `MessageBubble` component
- build `ChatScreen` using Scaffold, LazyColumn and bottom input
- add previews for empty, filled, loading and error states

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68619ecccb1c8328833d9b2abed57f04