### PR TITLE
Use conversation history for chat requests

### DIFF
--- a/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
@@ -24,9 +24,9 @@ import kotlinx.coroutines.withContext
 class ChatRepository(
     private val api: FoundryApiService
 ) {
-    suspend fun sendMessage(prompt: String): String = withContext(Dispatchers.IO) {
+    suspend fun sendMessage(messages: List<Message>): String = withContext(Dispatchers.IO) {
         return@withContext try {
-            val response = api.sendMessage(FoundryRequest(listOf(Message("user", prompt))))
+            val response = api.sendMessage(FoundryRequest(messages))
             if (response.isSuccessful) {
                 val body = response.body()
                 // Log raw JSON for debugging while hooking up the API

--- a/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
@@ -47,12 +47,14 @@ class ChatViewModel(
     fun sendMessage(prompt: String) {
         if (prompt.isBlank()) return
 
-        messages += Message(role = "user", content = prompt)
+        val userMessage = Message(role = "user", content = prompt)
+        val conversation = messages + userMessage
+        messages += userMessage
         inputText = ""
 
         viewModelScope.launch {
             isLoading = true
-            val reply = repository.sendMessage(prompt)
+            val reply = repository.sendMessage(conversation)
             isLoading = false
 
             if (reply.startsWith("Error")) {

--- a/app/src/test/java/com/booji/foundryconnect/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/booji/foundryconnect/data/repository/ChatRepositoryTest.kt
@@ -59,7 +59,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setBody(json).setResponseCode(200))
 
         // When
-        val reply = repo.sendMessage("Hi there")
+        val reply = repo.sendMessage(listOf(Message("user", "Hi there")))
 
         // Then
         assertEquals("Hello, Ant!", reply)
@@ -85,7 +85,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setBody(json).setResponseCode(200))
 
         // When
-        val reply = repo.sendMessage("Give me two")
+        val reply = repo.sendMessage(listOf(Message("user", "Give me two")))
 
         // Then
         assertEquals("First reply", reply)
@@ -97,7 +97,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(500).setBody("Internal error"))
 
         // When
-        val reply = repo.sendMessage("Kaboom")
+        val reply = repo.sendMessage(listOf(Message("user", "Kaboom")))
 
         // Then
         assertTrue(reply.contains("500"))
@@ -111,7 +111,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(json))
 
         // When
-        val reply = repo.sendMessage("No answer")
+        val reply = repo.sendMessage(listOf(Message("user", "No answer")))
 
         // Then
         assertEquals("No response from Foundry", reply)
@@ -125,7 +125,7 @@ class ChatRepositoryTest {
         )
 
         // When
-        val reply = repo.sendMessage("Fail")
+        val reply = repo.sendMessage(listOf(Message("user", "Fail")))
 
         // Then
         assertTrue(reply.startsWith("Error"))


### PR DESCRIPTION
## Summary
- adjust `ChatRepository.sendMessage` to accept a list of `Message`
- build `FoundryRequest` from that list
- send the whole conversation from `ChatViewModel`
- update repository unit tests for new API

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6862552491a483288092f618270771be