### PR TITLE
Add settings screen and DataStore configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
     implementation(libs.logging.interceptor)
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.mockwebserver.v500alpha14)
 }

--- a/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
+++ b/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
@@ -1,0 +1,42 @@
+package com.booji.foundryconnect
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+import com.booji.foundryconnect.data.prefs.SettingsDataStore
+import com.booji.foundryconnect.ui.ChatViewModel
+import com.booji.foundryconnect.ui.createRepository
+import com.booji.foundryconnect.ui.screens.ChatScreen
+import com.booji.foundryconnect.ui.screens.SettingsScreen
+
+/**
+ * Root composable handling simple in-app navigation and repository setup.
+ */
+@Composable
+fun FoundryChatApp() {
+    val context = LocalContext.current
+    val store = remember { SettingsDataStore(context) }
+
+    // Observe stored values with BuildConfig fallbacks
+    val project by store.projectId.collectAsState(initial = BuildConfig.AZURE_PROJECT)
+    val model by store.modelName.collectAsState(initial = BuildConfig.AZURE_MODEL)
+    val key by store.apiKey.collectAsState(initial = BuildConfig.AZURE_API_KEY)
+
+    // Rebuild repository when settings change
+    val repository = remember(project, model, key) {
+        createRepository(
+            project.ifBlank { BuildConfig.AZURE_PROJECT },
+            model.ifBlank { BuildConfig.AZURE_MODEL },
+            key.ifBlank { BuildConfig.AZURE_API_KEY }
+        )
+    }
+    val viewModel = remember(repository) { ChatViewModel(repository) }
+
+    var screen by remember { mutableStateOf<Screen>(Screen.Chat) }
+
+    when (screen) {
+        Screen.Chat -> ChatScreen(viewModel, onOpenSettings = { screen = Screen.Settings })
+        Screen.Settings -> SettingsScreen(store) { screen = Screen.Chat }
+    }
+}
+
+private enum class Screen { Chat, Settings }

--- a/app/src/main/java/com/booji/foundryconnect/MainActivity.kt
+++ b/app/src/main/java/com/booji/foundryconnect/MainActivity.kt
@@ -4,15 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.booji.foundryconnect.ui.theme.FoundryConnectTheme
-import com.booji.foundryconnect.ui.screens.ChatScreen
 
 
 /**
@@ -25,7 +19,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             FoundryConnectTheme {
-                ChatScreen()
+                FoundryChatApp()
             }
         }
     }

--- a/app/src/main/java/com/booji/foundryconnect/data/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/prefs/SettingsDataStore.kt
@@ -1,0 +1,41 @@
+package com.booji.foundryconnect.data.prefs
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.settingsDataStore by preferencesDataStore(name = "settings")
+
+/**
+ * Simple DataStore wrapper for persisting API configuration.
+ */
+class SettingsDataStore(private val context: Context) {
+
+    /** Flow of the stored Azure project id. */
+    val projectId: Flow<String> = context.settingsDataStore.data.map { it[KEY_PROJECT] ?: "" }
+
+    /** Flow of the stored model name. */
+    val modelName: Flow<String> = context.settingsDataStore.data.map { it[KEY_MODEL] ?: "" }
+
+    /** Flow of the stored API key. */
+    val apiKey: Flow<String> = context.settingsDataStore.data.map { it[KEY_KEY] ?: "" }
+
+    /** Persist all values in DataStore. */
+    suspend fun save(project: String, model: String, key: String) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[KEY_PROJECT] = project
+            prefs[KEY_MODEL] = model
+            prefs[KEY_KEY] = key
+        }
+    }
+
+    private companion object {
+        val KEY_PROJECT = stringPreferencesKey("project_id")
+        val KEY_MODEL = stringPreferencesKey("model_name")
+        val KEY_KEY = stringPreferencesKey("api_key")
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
@@ -22,7 +22,10 @@ import com.booji.foundryconnect.ui.components.MessageBubble
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChatScreen(viewModel: ChatViewModel = remember { ChatViewModel() }) {
+fun ChatScreen(
+    viewModel: ChatViewModel = remember { ChatViewModel() },
+    onOpenSettings: () -> Unit = {}
+) {
     val error = viewModel.errorMessage
     val loading = viewModel.isLoading
 
@@ -36,7 +39,12 @@ fun ChatScreen(viewModel: ChatViewModel = remember { ChatViewModel() }) {
     }
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Foundry Chat") })
+            TopAppBar(
+                title = { Text("Foundry Chat") },
+                actions = {
+                    TextButton(onClick = onOpenSettings) { Text("Settings") }
+                }
+            )
         },
         bottomBar = {
             MessageInput(

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/SettingsScreen.kt
@@ -1,0 +1,67 @@
+package com.booji.foundryconnect.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.booji.foundryconnect.data.prefs.SettingsDataStore
+import kotlinx.coroutines.launch
+
+/** Screen allowing entry of Azure credentials. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(store: SettingsDataStore, onBack: () -> Unit) {
+    val scope = rememberCoroutineScope()
+
+    val currentProject by store.projectId.collectAsState(initial = "")
+    val currentModel by store.modelName.collectAsState(initial = "")
+    val currentKey by store.apiKey.collectAsState(initial = "")
+
+    var project by remember { mutableStateOf(currentProject) }
+    var model by remember { mutableStateOf(currentModel) }
+    var key by remember { mutableStateOf(currentKey) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    TextButton(onClick = onBack) { Text("Back") }
+                }
+            )
+        }
+    ) { inner ->
+        Column(modifier = Modifier.padding(inner).padding(16.dp)) {
+            OutlinedTextField(
+                value = project,
+                onValueChange = { project = it },
+                label = { Text("Project ID") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = model,
+                onValueChange = { model = it },
+                label = { Text("Model Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = key,
+                onValueChange = { key = it },
+                label = { Text("API Key") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = {
+                scope.launch {
+                    store.save(project, model, key)
+                    onBack()
+                }
+            }) {
+                Text("Save")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ okhttpTestingSupport = "5.0.0-alpha.14"
 retrofit = "3.0.0"
 kotlinxCoroutinesTest = "1.10.2"
 mockWebServer = "5.0.0-alpha.16"
+datastore = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +42,7 @@ mockwebserver-v500alpha14 = { module = "com.squareup.okhttp3:mockwebserver", ver
 okhttp-testing-support = { module = "com.squareup.okhttp3:okhttp-testing-support", version.ref = "okhttpTestingSupport" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockWebServer" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 [plugins]


### PR DESCRIPTION
## Summary
- implement `SettingsDataStore` for persisting project, model and key
- create new `SettingsScreen` to edit these values
- add button in chat to navigate to settings
- build Retrofit client from stored values at startup
- wire up new `FoundryChatApp` root composable
- include DataStore dependency in Gradle

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6862599f21e483288b0e7ffb25bde0ad