### PR TITLE
Add chat history support

### DIFF
--- a/app/src/main/java/com/booji/foundryconnect/data/history/ChatHistoryStore.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/history/ChatHistoryStore.kt
@@ -1,0 +1,68 @@
+package com.booji.foundryconnect.data.history
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.chatDataStore by preferencesDataStore(name = "chat_history")
+
+/**
+ * DataStore wrapper for persisting recent chat conversations.
+ */
+class ChatHistoryStore(private val context: Context) {
+
+    private val gson = Gson()
+    private val KEY_CHATS = stringPreferencesKey("chats_json")
+
+    /** Flow of all stored chats, newest last. */
+    val chats: Flow<List<ChatRecord>> = context.chatDataStore.data.map { prefs ->
+        prefs[KEY_CHATS]?.let { json ->
+            try {
+                gson.fromJson(json, Array<ChatRecord>::class.java)?.toList() ?: emptyList()
+            } catch (_: Exception) {
+                emptyList()
+            }
+        } ?: emptyList()
+    }
+
+    /** Persist the given chat, trimming history to [MAX_CHATS]. */
+    suspend fun saveChat(record: ChatRecord) {
+        context.chatDataStore.edit { prefs ->
+            val current = prefs[KEY_CHATS]
+            val list = if (!current.isNullOrBlank()) {
+                try {
+                    gson.fromJson(current, Array<ChatRecord>::class.java)?.toMutableList() ?: mutableListOf()
+                } catch (_: Exception) { mutableListOf() }
+            } else mutableListOf()
+            list.removeAll { it.id == record.id }
+            list.add(record)
+            if (list.size > MAX_CHATS) {
+                repeat(list.size - MAX_CHATS) { list.removeAt(0) }
+            }
+            prefs[KEY_CHATS] = gson.toJson(list)
+        }
+    }
+
+    /** Remove a chat by id. */
+    suspend fun deleteChat(id: String) {
+        context.chatDataStore.edit { prefs ->
+            val current = prefs[KEY_CHATS]
+            if (!current.isNullOrBlank()) {
+                val list = try {
+                    gson.fromJson(current, Array<ChatRecord>::class.java)?.toMutableList() ?: mutableListOf()
+                } catch (_: Exception) { mutableListOf() }
+                list.removeAll { it.id == id }
+                prefs[KEY_CHATS] = gson.toJson(list)
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_CHATS = 10
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/data/history/ChatRecord.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/history/ChatRecord.kt
@@ -1,0 +1,11 @@
+package com.booji.foundryconnect.data.history
+
+import com.booji.foundryconnect.data.network.Message
+
+/**
+ * Simple container for a stored chat conversation.
+ */
+data class ChatRecord(
+    val id: String,
+    val messages: List<Message>
+)

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatListScreen.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatListScreen.kt
@@ -1,0 +1,74 @@
+package com.booji.foundryconnect.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.booji.foundryconnect.data.history.ChatHistoryStore
+import com.booji.foundryconnect.data.history.ChatRecord
+import kotlinx.coroutines.launch
+
+/**
+ * Simple screen listing previous chats with options to resume or delete.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatListScreen(
+    store: ChatHistoryStore,
+    onStartNew: () -> Unit,
+    onOpenChat: (ChatRecord) -> Unit
+) {
+    val chats by store.chats.collectAsState(initial = emptyList())
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Previous Chats") }) }
+    ) { inner ->
+        Column(modifier = Modifier.padding(inner).fillMaxSize()) {
+            Button(onClick = onStartNew, modifier = Modifier.padding(16.dp)) {
+                Text("Start New Chat")
+            }
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(chats) { chat ->
+                    ChatRow(
+                        chat = chat,
+                        onOpen = { onOpenChat(chat) },
+                        onDelete = { scope.launch { store.deleteChat(chat.id) } }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatRow(chat: ChatRecord, onOpen: () -> Unit, onDelete: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        val preview = chat.messages.firstOrNull()?.content?.take(40) ?: "(empty)"
+        Button(onClick = onOpen) { Text(preview) }
+        Spacer(Modifier.width(8.dp))
+        Button(onClick = onDelete) { Text("Delete") }
+    }
+}


### PR DESCRIPTION
## Summary
- store up to 10 chats in a new `ChatHistoryStore`
- allow choosing previous chats or starting a new one via `ChatListScreen`
- wire history into `ChatViewModel` and app navigation

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6862d7e88ac083288eeb0bf6906a034a