### PR TITLE
Add token and history settings

### DIFF
--- a/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
+++ b/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
@@ -32,7 +32,7 @@ fun FoundryChatApp() {
             key.ifBlank { BuildConfig.AZURE_API_KEY }
         )
     }
-    val viewModel = remember(repository, chatStore) { ChatViewModel(repository, chatStore) }
+    val viewModel = remember(repository, chatStore, store) { ChatViewModel(repository, chatStore, store) }
 
     val chats by chatStore.chats.collectAsState(initial = emptyList())
     var screen by remember { mutableStateOf<Screen?>(null) }

--- a/app/src/main/java/com/booji/foundryconnect/data/history/HistoryReducer.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/history/HistoryReducer.kt
@@ -1,0 +1,38 @@
+package com.booji.foundryconnect.data.history
+
+import com.booji.foundryconnect.data.network.Message
+
+/**
+ * Utility for trimming chat history before sending to the API.
+ */
+object HistoryReducer {
+    /**
+     * Builds a request context containing [systemMessage] and the most recent
+     * messages up to [maxWords]. Entire messages are kept; older messages are
+     * dropped when the limit is exceeded.
+     */
+    fun buildContext(
+        history: List<Message>,
+        systemMessage: String,
+        maxWords: Int
+    ): List<Message> {
+        val result = mutableListOf<Message>()
+        if (systemMessage.isNotBlank()) {
+            result += Message(role = "system", content = systemMessage)
+        }
+
+        var wordCount = 0
+        val trimmed = mutableListOf<Message>()
+        for (msg in history.asReversed()) {
+            val count = msg.content.trim().split(Regex("\\s+")).size
+            if (wordCount + count > maxWords) break
+            trimmed.add(0, msg)
+            wordCount += count
+        }
+        if (trimmed.size < history.size) {
+            trimmed.add(0, Message("user", "Some old messages removed from context..."))
+        }
+        result.addAll(trimmed)
+        return result
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/data/prefs/SettingsDataStore.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/prefs/SettingsDataStore.kt
@@ -3,6 +3,7 @@ package com.booji.foundryconnect.data.prefs
 import android.content.Context
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -24,12 +25,31 @@ class SettingsDataStore(private val context: Context) {
     /** Flow of the stored API key. */
     val apiKey: Flow<String> = context.settingsDataStore.data.map { it[KEY_KEY] ?: "" }
 
+    /** Flow of the configured max tokens for API requests. */
+    val maxTokens: Flow<Int> = context.settingsDataStore.data.map { it[KEY_MAX_TOKENS] ?: 256 }
+
+    /** Flow of the history word limit used when sending requests. */
+    val historyWords: Flow<Int> = context.settingsDataStore.data.map { it[KEY_HISTORY_WORDS] ?: 1000 }
+
+    /** Flow of the optional system prompt. */
+    val systemMessage: Flow<String> = context.settingsDataStore.data.map { it[KEY_SYSTEM_MESSAGE] ?: "" }
+
     /** Persist all values in DataStore. */
-    suspend fun save(project: String, model: String, key: String) {
+    suspend fun save(
+        project: String,
+        model: String,
+        key: String,
+        maxTokens: Int,
+        historyWords: Int,
+        systemMessage: String
+    ) {
         context.settingsDataStore.edit { prefs ->
             prefs[KEY_PROJECT] = project
             prefs[KEY_MODEL] = model
             prefs[KEY_KEY] = key
+            prefs[KEY_MAX_TOKENS] = maxTokens
+            prefs[KEY_HISTORY_WORDS] = historyWords
+            prefs[KEY_SYSTEM_MESSAGE] = systemMessage
         }
     }
 
@@ -37,5 +57,8 @@ class SettingsDataStore(private val context: Context) {
         val KEY_PROJECT = stringPreferencesKey("project_id")
         val KEY_MODEL = stringPreferencesKey("model_name")
         val KEY_KEY = stringPreferencesKey("api_key")
+        val KEY_MAX_TOKENS = intPreferencesKey("max_tokens")
+        val KEY_HISTORY_WORDS = intPreferencesKey("history_words")
+        val KEY_SYSTEM_MESSAGE = stringPreferencesKey("system_message")
     }
 }

--- a/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
@@ -24,9 +24,9 @@ import kotlinx.coroutines.withContext
 class ChatRepository(
     private val api: FoundryApiService
 ) {
-    suspend fun sendMessage(messages: List<Message>): String = withContext(Dispatchers.IO) {
+    suspend fun sendMessage(messages: List<Message>, maxTokens: Int): String = withContext(Dispatchers.IO) {
         return@withContext try {
-            val response = api.sendMessage(FoundryRequest(messages))
+            val response = api.sendMessage(FoundryRequest(messages, maxTokens))
             if (response.isSuccessful) {
                 val body = response.body()
                 // Log raw JSON for debugging while hooking up the API

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/SettingsScreen.kt
@@ -17,10 +17,16 @@ fun SettingsScreen(store: SettingsDataStore, onBack: () -> Unit) {
     val currentProject by store.projectId.collectAsState(initial = "")
     val currentModel by store.modelName.collectAsState(initial = "")
     val currentKey by store.apiKey.collectAsState(initial = "")
+    val currentTokens by store.maxTokens.collectAsState(initial = 256)
+    val currentHistory by store.historyWords.collectAsState(initial = 1000)
+    val currentSystem by store.systemMessage.collectAsState(initial = "")
 
     var project by remember { mutableStateOf(currentProject) }
     var model by remember { mutableStateOf(currentModel) }
     var key by remember { mutableStateOf(currentKey) }
+    var tokens by remember { mutableStateOf(currentTokens.toString()) }
+    var history by remember { mutableStateOf(currentHistory.toString()) }
+    var system by remember { mutableStateOf(currentSystem) }
 
     Scaffold(
         topBar = {
@@ -53,10 +59,33 @@ fun SettingsScreen(store: SettingsDataStore, onBack: () -> Unit) {
                 label = { Text("API Key") },
                 modifier = Modifier.fillMaxWidth()
             )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = tokens,
+                onValueChange = { tokens = it },
+                label = { Text("Max Tokens") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = history,
+                onValueChange = { history = it },
+                label = { Text("History Words") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = system,
+                onValueChange = { system = it },
+                label = { Text("System Prompt") },
+                modifier = Modifier.fillMaxWidth()
+            )
             Spacer(Modifier.height(16.dp))
             Button(onClick = {
                 scope.launch {
-                    store.save(project, model, key)
+                    val t = tokens.toIntOrNull() ?: 256
+                    val h = history.toIntOrNull() ?: 1000
+                    store.save(project, model, key, t, h, system)
                     onBack()
                 }
             }) {

--- a/app/src/test/java/com/booji/foundryconnect/data/history/HistoryReducerTest.kt
+++ b/app/src/test/java/com/booji/foundryconnect/data/history/HistoryReducerTest.kt
@@ -1,0 +1,22 @@
+package com.booji.foundryconnect.data.history
+
+import com.booji.foundryconnect.data.network.Message
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HistoryReducerTest {
+    @Test
+    fun buildContext_trimsOldMessagesAndAddsPlaceholder() {
+        val history = listOf(
+            Message("user", "First message"),
+            Message("assistant", "Reply one"),
+            Message("user", "Second message")
+        )
+        val result = HistoryReducer.buildContext(history, "sys", 3)
+        // Should keep only the last message plus placeholder and system
+        assertEquals(3, result.size)
+        assertEquals("system", result[0].role)
+        assertEquals("Some old messages removed from context...", result[1].content)
+        assertEquals("Second message", result[2].content)
+    }
+}

--- a/app/src/test/java/com/booji/foundryconnect/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/booji/foundryconnect/data/repository/ChatRepositoryTest.kt
@@ -59,7 +59,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setBody(json).setResponseCode(200))
 
         // When
-        val reply = repo.sendMessage(listOf(Message("user", "Hi there")))
+        val reply = repo.sendMessage(listOf(Message("user", "Hi there")), 256)
 
         // Then
         assertEquals("Hello, Ant!", reply)
@@ -85,7 +85,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setBody(json).setResponseCode(200))
 
         // When
-        val reply = repo.sendMessage(listOf(Message("user", "Give me two")))
+        val reply = repo.sendMessage(listOf(Message("user", "Give me two")), 256)
 
         // Then
         assertEquals("First reply", reply)
@@ -97,7 +97,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(500).setBody("Internal error"))
 
         // When
-        val reply = repo.sendMessage(listOf(Message("user", "Kaboom")))
+        val reply = repo.sendMessage(listOf(Message("user", "Kaboom")), 256)
 
         // Then
         assertTrue(reply.contains("500"))
@@ -111,7 +111,7 @@ class ChatRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(json))
 
         // When
-        val reply = repo.sendMessage(listOf(Message("user", "No answer")))
+        val reply = repo.sendMessage(listOf(Message("user", "No answer")), 256)
 
         // Then
         assertEquals("No response from Foundry", reply)
@@ -125,7 +125,7 @@ class ChatRepositoryTest {
         )
 
         // When
-        val reply = repo.sendMessage(listOf(Message("user", "Fail")))
+        val reply = repo.sendMessage(listOf(Message("user", "Fail")), 256)
 
         // Then
         assertTrue(reply.startsWith("Error"))


### PR DESCRIPTION
## Summary
- extend `SettingsDataStore` with max tokens, history limit and system message
- add input fields to `SettingsScreen`
- trim conversation using new `HistoryReducer`
- pass settings to `ChatViewModel` and repository
- update tests for new parameters and add `HistoryReducerTest`

## Testing
- `./gradlew test --quiet` *(fails: Could not finish due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68630310d3d08328b02eca635de8809b