### PR TITLE
Render chat bubbles with Markdown

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     implementation(libs.converter.gson)
     implementation(libs.logging.interceptor)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.markwon.core)
 
     testImplementation(libs.mockwebserver.v500alpha14)
 }

--- a/app/src/main/java/com/booji/foundryconnect/ui/components/MessageBubble.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/components/MessageBubble.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import com.booji.foundryconnect.ui.util.MarkdownText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +29,7 @@ fun MessageBubble(message: String, isUser: Boolean) {
             .padding(if (isUser) 8.dp else 4.dp)
     ) {
         Box(modifier = Modifier.padding(8.dp), contentAlignment = Alignment.CenterStart) {
-            Text(text = message)
+            MarkdownText(text = message)
         }
     }
 }

--- a/app/src/main/java/com/booji/foundryconnect/ui/util/MarkdownFormatter.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/util/MarkdownFormatter.kt
@@ -1,0 +1,33 @@
+package com.booji.foundryconnect.ui.util
+
+import android.content.Context
+import android.text.Spanned
+import io.noties.markwon.Markwon
+
+/**
+ * Simple wrapper around [Markwon] so the rest of the code doesn't
+ * need to know about the library. Call [init] once with an Android
+ * [Context] then use [parse] to convert markdown strings to [Spanned].
+ */
+object MarkdownFormatter {
+    private var markwon: Markwon? = null
+
+    /**
+     * Initialise the underlying [Markwon] instance if required.
+     */
+    fun init(context: Context) {
+        if (markwon == null) {
+            markwon = Markwon.create(context)
+        }
+    }
+
+    /**
+     * Convert the given markdown text into a [Spanned] instance.
+     * [init] must be called before using this function.
+     */
+    fun parse(markdown: String): Spanned {
+        val mk = markwon
+            ?: throw IllegalStateException("MarkdownFormatter not initialised")
+        return mk.toMarkdown(markdown)
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/ui/util/MarkdownText.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/util/MarkdownText.kt
@@ -1,0 +1,25 @@
+package com.booji.foundryconnect.ui.util
+
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+
+/**
+ * Displays markdown content using a [TextView] and [MarkdownFormatter].
+ */
+@Composable
+fun MarkdownText(text: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    // Ensure Markwon instance exists
+    MarkdownFormatter.init(context)
+    val parsed = remember(text) { MarkdownFormatter.parse(text) }
+    AndroidView(
+        factory = { TextView(context) },
+        modifier = modifier
+    ) { view ->
+        view.text = parsed
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ retrofit = "3.0.0"
 kotlinxCoroutinesTest = "1.10.2"
 mockWebServer = "5.0.0-alpha.16"
 datastore = "1.1.0"
+markwon = "4.6.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -44,6 +45,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockWebServer" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Markwon dependency for Markdown support
- wrap Markwon in a utility object
- provide a `MarkdownText` composable for rendering
- use the new composable in `MessageBubble`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6863d9e816448328828cc48ebbd39815