### PR TITLE
Implement Azure OpenAI backend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     implementation(libs.logging.interceptor)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.markwon.core)
+    implementation(libs.azure.ai.openai)
     implementation(libs.semantickernel.core)
     implementation(libs.semantickernel.aiservices.openai)
 

--- a/app/src/main/java/com/booji/foundryconnect/data/network/AzureOpenAiService.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/network/AzureOpenAiService.kt
@@ -1,0 +1,55 @@
+package com.booji.foundryconnect.data.network
+
+import com.azure.ai.openai.OpenAIClient
+import com.azure.ai.openai.OpenAIClientBuilder
+import com.azure.ai.openai.models.ChatCompletionsOptions
+import com.azure.ai.openai.models.ChatRequestAssistantMessage
+import com.azure.ai.openai.models.ChatRequestMessage
+import com.azure.ai.openai.models.ChatRequestSystemMessage
+import com.azure.ai.openai.models.ChatRequestUserMessage
+import com.azure.core.credential.AzureKeyCredential
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Chat backend using the Azure OpenAI SDK directly.
+ */
+class AzureOpenAiService(
+    projectId: String,
+    private val deployment: String,
+    apiKey: String
+) : ChatBackend {
+
+    private val client: OpenAIClient
+
+    init {
+        val endpoint = "https://$projectId.cognitiveservices.azure.com/"
+        client = OpenAIClientBuilder()
+            .credential(AzureKeyCredential(apiKey))
+            .endpoint(endpoint)
+            .buildClient()
+    }
+
+    override suspend fun sendMessage(messages: List<Message>, maxTokens: Int): String =
+        withContext(Dispatchers.IO) {
+            try {
+                val reqMessages = messages.map { msg ->
+                    when (msg.role) {
+                        "assistant" -> ChatRequestAssistantMessage(msg.content)
+                        "system" -> ChatRequestSystemMessage(msg.content)
+                        else -> ChatRequestUserMessage(msg.content)
+                    }
+                }
+                val options = ChatCompletionsOptions(reqMessages).apply {
+                    setMaxTokens(maxTokens)
+                    setTemperature(1.0)
+                    setTopP(1.0)
+                }
+                val result = client.getChatCompletions(deployment, options)
+                val first = result.choices.firstOrNull()?.message?.content
+                first ?: "No response from Foundry"
+            } catch (e: Exception) {
+                "Error: ${e.message}"
+            }
+        }
+}

--- a/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/repository/ChatRepository.kt
@@ -2,8 +2,6 @@ package com.booji.foundryconnect.data.repository
 
 import com.booji.foundryconnect.data.network.ChatBackend
 import com.booji.foundryconnect.data.network.Message
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 
 /**
@@ -15,8 +13,8 @@ import kotlinx.coroutines.withContext
 class ChatRepository(
     private val backend: ChatBackend
 ) {
-    suspend fun sendMessage(messages: List<Message>, maxTokens: Int): String = withContext(Dispatchers.IO) {
-        backend.sendMessage(messages, maxTokens)
+    suspend fun sendMessage(messages: List<Message>, maxTokens: Int): String {
+        return backend.sendMessage(messages, maxTokens)
     }
 
 }

--- a/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.booji.foundryconnect.BuildConfig
-import com.booji.foundryconnect.data.network.SemanticKernelService
+import com.booji.foundryconnect.data.network.AzureOpenAiService
 import com.booji.foundryconnect.data.network.Message
 import com.booji.foundryconnect.data.repository.ChatRepository
 import com.booji.foundryconnect.data.history.ChatHistoryStore
@@ -118,7 +118,7 @@ class ChatViewModel(
  * Helper to construct a [ChatRepository] from runtime settings.
  */
 fun createRepository(project: String, model: String, apiKey: String): ChatRepository {
-    val backend = SemanticKernelService(project, model, apiKey)
+    val backend = AzureOpenAiService(project, model, apiKey)
     return ChatRepository(backend)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.11.0"
-azureAiOpenai = "1.1.0"
+azureAiOpenai = "1.0.0-beta.16"
 converterGson = "3.0.0"
 dotenvKotlin = "6.5.1"
 kotlin = "2.0.21"


### PR DESCRIPTION
## Summary
- add `AzureOpenAiService` backend using Azure SDK
- wire `ChatViewModel` to new backend
- expose Azure OpenAI client dependency
- simplify `ChatRepository` coroutine usage
- update library version catalog

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686403c35e8c8328b9580cea0ba862b3