### PR TITLE
Integrate SemanticKernel with web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Create an environment file at `app/assets/env` before building the project. The 
 AZURE_PROJECT=<your-project-id>
 AZURE_MODEL=<your-model-name>
 AZURE_API_KEY=<your-api-key>
+BING_API_KEY=<your-bing-search-key>
 ```
 
 These values populate the BuildConfig fields defined in `app/build.gradle.kts`:
@@ -33,7 +34,7 @@ val envMap: Map<String, String> = if (envFile.exists()) {
 }
 ```
 
-The `AZURE_PROJECT`, `AZURE_MODEL`, and `AZURE_API_KEY` fields are later retrieved using `BuildConfig`.
+The `AZURE_PROJECT`, `AZURE_MODEL`, `AZURE_API_KEY`, and `BING_API_KEY` fields are later retrieved using `BuildConfig`.
 
 ## DataStore settings
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,11 @@ android {
             "AZURE_API_KEY",
             "\"${envMap["AZURE_API_KEY"] ?: ""}\""
         )
+        buildConfigField(
+            "String",
+            "BING_API_KEY",
+            "\"${envMap["BING_API_KEY"] ?: ""}\""
+        )
     }
 
     buildTypes {

--- a/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
+++ b/app/src/main/java/com/booji/foundryconnect/FoundryChatApp.kt
@@ -30,7 +30,8 @@ fun FoundryChatApp() {
         createRepository(
             project.ifBlank { BuildConfig.AZURE_PROJECT },
             model.ifBlank { BuildConfig.AZURE_MODEL },
-            key.ifBlank { BuildConfig.AZURE_API_KEY }
+            key.ifBlank { BuildConfig.AZURE_API_KEY },
+            BuildConfig.BING_API_KEY
         )
     }
     val viewModel = remember(repository, chatStore, store) { ChatViewModel(repository, chatStore, store) }

--- a/app/src/main/java/com/booji/foundryconnect/data/network/SemanticKernelService.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/network/SemanticKernelService.kt
@@ -4,8 +4,6 @@ import com.azure.ai.openai.OpenAIClientBuilder
 import com.azure.core.credential.AzureKeyCredential
 import com.microsoft.semantickernel.Kernel
 import com.microsoft.semantickernel.plugin.KernelPluginFactory
-import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction
-import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory
 import com.microsoft.semantickernel.services.chatcompletion.message.ChatMessageTextContent
@@ -19,7 +17,7 @@ class SemanticKernelService(
     projectId: String,
     private val model: String,
     apiKey: String,
-    private val serviceId: String = "foundry"
+    private val searchKey: String
 ) : ChatBackend {
 
     private val kernel: Kernel
@@ -41,7 +39,7 @@ class SemanticKernelService(
 
         kernel = Kernel.builder()
             .withAIService(ChatCompletionService::class.java, completion)
-            .withPlugin(KernelPluginFactory.createFromObject(EchoPlugin(), "echo"))
+            .withPlugin(KernelPluginFactory.createFromObject(WebSearchPlugin(searchKey), "web"))
             .build()
 
         chat = kernel.getService(ChatCompletionService::class.java)
@@ -67,18 +65,4 @@ class SemanticKernelService(
                 "Error: ${e.message}"
             }
         }
-
-    private class EchoPlugin {
-        @DefineKernelFunction(
-            name = "echo",
-            description = "Echo the provided text",
-            returnType = "String",
-            returnDescription = "Echo result",
-            samples = []
-        )
-        fun echo(
-            @KernelFunctionParameter(name = "text", description = "Text to echo")
-            text: String
-        ): String = text
-    }
 }

--- a/app/src/main/java/com/booji/foundryconnect/data/network/WebSearchPlugin.kt
+++ b/app/src/main/java/com/booji/foundryconnect/data/network/WebSearchPlugin.kt
@@ -1,0 +1,50 @@
+package com.booji.foundryconnect.data.network
+
+import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction
+import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.net.URLEncoder
+
+/**
+ * Simple plugin exposing a Bing Web Search function to Semantic Kernel.
+ */
+class WebSearchPlugin(private val apiKey: String) {
+
+    private val client = OkHttpClient()
+
+    @DefineKernelFunction(
+        name = "web_search",
+        description = "Search the web and return a short snippet from the top result",
+        returnType = "String",
+        returnDescription = "Snippet text"
+    )
+    fun search(
+        @KernelFunctionParameter(name = "query", description = "Search query")
+        query: String
+    ): String {
+        return try {
+            val encoded = URLEncoder.encode(query, "UTF-8")
+            val url = "https://api.bing.microsoft.com/v7.0/search?q=$encoded&count=1"
+            val request = Request.Builder()
+                .url(url)
+                .addHeader("Ocp-Apim-Subscription-Key", apiKey)
+                .build()
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    return "Error ${'$'}{resp.code}"
+                }
+                val json = JSONObject(resp.body?.string().orEmpty())
+                val snippet = json
+                    .optJSONObject("webPages")
+                    ?.optJSONArray("value")
+                    ?.optJSONObject(0)
+                    ?.optString("snippet")
+                snippet ?: "No results"
+            }
+        } catch (e: Exception) {
+            "Error: ${'$'}{e.message}"
+        }
+    }
+}

--- a/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/ChatViewModel.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.booji.foundryconnect.BuildConfig
-import com.booji.foundryconnect.data.network.AzureOpenAiService
+import com.booji.foundryconnect.data.network.SemanticKernelService
 import com.booji.foundryconnect.data.network.Message
 import com.booji.foundryconnect.data.repository.ChatRepository
 import com.booji.foundryconnect.data.history.ChatHistoryStore
@@ -109,7 +109,8 @@ class ChatViewModel(
         fun defaultRepository(): ChatRepository = createRepository(
             BuildConfig.AZURE_PROJECT,
             BuildConfig.AZURE_MODEL,
-            BuildConfig.AZURE_API_KEY
+            BuildConfig.AZURE_API_KEY,
+            BuildConfig.BING_API_KEY
         )
     }
 }
@@ -117,8 +118,8 @@ class ChatViewModel(
 /**
  * Helper to construct a [ChatRepository] from runtime settings.
  */
-fun createRepository(project: String, model: String, apiKey: String): ChatRepository {
-    val backend = AzureOpenAiService(project, model, apiKey)
+fun createRepository(project: String, model: String, apiKey: String, searchKey: String): ChatRepository {
+    val backend = SemanticKernelService(project, model, apiKey, searchKey)
     return ChatRepository(backend)
 }
 


### PR DESCRIPTION
## Summary
- switch default backend to `SemanticKernelService`
- remove Echo plugin and add a new `WebSearchPlugin`
- include Bing search key in environment and build config
- wire repository creation through the new service

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68643ed96b548328b16742f254af6ef7