### PR TITLE
Fix chat text field insets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ android-commandlinetools.zip
 env
 .env
 assets/env
+.kotlin/

--- a/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
+++ b/app/src/main/java/com/booji/foundryconnect/ui/screens/ChatScreens.kt
@@ -49,12 +49,25 @@ fun ChatScreen(
             )
         },
         bottomBar = {
-            MessageInput(
-                text = viewModel.inputText,
-                onTextChange = { viewModel.inputText = it },
-                onSend = { viewModel.sendMessage(it) },
-                enabled = !loading
-            )
+            // Place the message input above the navigation bar and keyboard
+            // so it remains accessible when these system UI elements are shown
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(
+                        WindowInsets
+                            .navigationBars
+                            .union(WindowInsets.ime)
+                    )
+            ) {
+                MessageInput(
+                    text = viewModel.inputText,
+                    onTextChange = { viewModel.inputText = it },
+                    onSend = { viewModel.sendMessage(it) },
+                    enabled = !loading,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     ) { inner ->
         Box(modifier = Modifier.padding(inner).fillMaxSize()) {
@@ -93,11 +106,12 @@ private fun MessageInput(
     text: String,
     onTextChange: (String) -> Unit,
     onSend: (String) -> Unit,
-    enabled: Boolean
+    enabled: Boolean,
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(8.dp)
     ) {


### PR DESCRIPTION
## Summary
- adjust bottom bar insets in ChatScreen so the input isn't hidden behind the navigation bar or keyboard
- allow passing a modifier to MessageInput
- ignore Kotlin daemon cache dir

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6865471455908328b131786a947a8cd3